### PR TITLE
Feature/230206 update dev env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+tmp/

--- a/build/.dockerignore
+++ b/build/.dockerignore
@@ -1,0 +1,2 @@
+.git
+.DS_Store

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20 as dev
+FROM golang:1.19.5 as dev
 WORKDIR /app
 RUN go install github.com/cosmtrek/air@latest
 CMD ["air", "-c", "./build/.air.toml"]

--- a/build/Makefile
+++ b/build/Makefile
@@ -2,6 +2,9 @@
 .PHONY: up down logs ps dry-migrate migrate help
 .DEFAULT_GOAL := help
 
+build-local: ## Build docker image to local development
+	docker compose build --no-cache
+
 up: ## Do docker compose up with hot reload
 	docker compose up -d
 

--- a/main.go
+++ b/main.go
@@ -1,7 +1,20 @@
 package main
 
-import "fmt"
+import (
+	"fmt"
+	"net/http"
+	"os"
+)
 
 func main() {
-    fmt.Println("Hello golang from docker!")
+    err := http.ListenAndServe(
+        ":18080",
+        http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+            fmt.Fprintf(w, "Hello, %s!", r.URL.Path[1:])
+        }),
+    )
+    if err != nil {
+        fmt.Printf("failed to terminate server: %v", err)
+        os.Exit(1)
+    }
 }


### PR DESCRIPTION
- a640c07 add ignore file settings
  - /tmp は airによって自動生成されるので無視する
  - dockerでimageをbuildする際に.gitを無視する
- d05a423 add build-local command
  - Makefileにlocalでdocker imageをbuildするコマンドを追加
- 1232719 Go lang version matched with local
  - ローカルのGoがver 1.19.5なので統一した
- 0a35d14 change sample main.go
  - 文字列を標準出力するサンプルからhttpサーバーのサンプルに変更 