### PR TITLE
Port number can be dynamically specified

### DIFF
--- a/main.go
+++ b/main.go
@@ -4,27 +4,41 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"net"
 	"net/http"
+	"os"
 
 	"golang.org/x/sync/errgroup"
 )
 
 func main() {
-	if err := run(context.Background()); err != nil {
+	if len(os.Args) != 2 {
+		log.Printf("need port number\n")
+		os.Exit(1)
+	}
+	p := os.Args[1]
+	l, err := net.Listen("tcp", ":"+p)
+	if err != nil {
+		log.Fatalf("failed to listen port %s: %v", p, err)
+	}
+	if err := run(context.Background(), l); err != nil {
 		log.Printf("failed to terminate server: %v", err)
+		os.Exit(1)
 	}
 }
 
 /*
 関数の外部からサーバーのプロセスを中断可能にする
- 1.*http.Server.ListenAndServeメソッドを実行してHTTPリクエストを受け付ける
- 2.引数で渡されたcontext.Contextを通じて処理の中断命令を検知した時は
-   *http.Server.ShutdownメソッドでHTTPサーバーの機能を終了する
- 3.run関数の戻り値として*http.Server.ListenAndServeメソッドの戻り値のエラーを返す
+動的にポート番号を変更可能する
+
+	1.*http.Server.ListenAndServeメソッドを実行してHTTPリクエストを受け付ける
+	2.引数で渡されたcontext.Contextを通じて処理の中断命令を検知した時は
+	  *http.Server.ShutdownメソッドでHTTPサーバーの機能を終了する
+	3.run関数の戻り値として*http.Server.ListenAndServeメソッドの戻り値のエラーを返す
 */
-func run(ctx context.Context) error {
+func run(ctx context.Context, l net.Listener) error {
 	s := &http.Server{
-		Addr: ":18080",
+		// 引数で受け取ったnet.Listenerを利用するので、Addrフィールドは指定しない
 		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			fmt.Fprintf(w, "Hello, %s!", r.URL.Path[1:])
 		}),
@@ -32,9 +46,10 @@ func run(ctx context.Context) error {
 	eg, ctx := errgroup.WithContext(ctx)
 	// 別ゴルーチンでHTTPサーバーを起動する
 	eg.Go(func() error {
+		// ListenAndServeメソッドではなく、Serveメソッドに変更する
 		// http.ErrServerClosedは
 		// http.Server.Shutdown()が正常に終了したことを示すので異常ではない
-		if err := s.ListenAndServe(); err != nil &&
+		if err := s.Serve(l); err != nil &&
 			err != http.ErrServerClosed {
 			log.Printf("failed to close: %+v", err)
 			return err
@@ -49,4 +64,3 @@ func run(ctx context.Context) error {
 	// Goメソッドで起動した別ゴルーチンの終了を待つ
 	return eg.Wait()
 }
-

--- a/main_test.go
+++ b/main_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"testing"
 
@@ -19,13 +20,20 @@ import (
 6 GETリクエストで取得したレスポンスボディが期待する文字列であることを検証する
 */
 func TestRun(t *testing.T) {
+	l, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatalf("failed to listen port %v", err)
+	}
 	ctx, cancel := context.WithCancel(context.Background())
 	eg, ctx := errgroup.WithContext(ctx)
 	eg.Go(func() error {
-		return run(ctx)
+		return run(ctx, l)
 	})
 	in := "message"
-	rsp, err := http.Get("http://localhost:18080/" + in)
+	url := fmt.Sprintf("http://%s/%s", l.Addr().String(), in)
+	// リッスンしているポート番号の確認
+	t.Logf("try request to %q", url)
+	rsp, err := http.Get(url)
 	if err != nil {
 		t.Errorf("failed to get: %+v", err)
 	}


### PR DESCRIPTION
## Error occurs if port number is not specified
<img width="670" alt="1" src="https://user-images.githubusercontent.com/20558599/218097935-ac5ceae0-cb11-48d7-b8d8-f25c979ec85c.png">

## The port number is automatically selected when the test is run
<img width="739" alt="2" src="https://user-images.githubusercontent.com/20558599/218097978-3e421da1-bdf1-413e-ab73-afba10f85d85.png">
